### PR TITLE
chore: release 0.1.1 for docs.rs rebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-desktop-underlay"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "gdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,15 @@ links        = "tauri-plugin-desktop-underlay"
 name         = "tauri-plugin-desktop-underlay"
 readme       = "README.md"
 repository   = "https://github.com/Charlie-XIAO/tauri-plugin-desktop-underlay"
-version      = "0.1.0"
+version      = "0.1.1"
+
+[package.metadata.docs.rs]
+default-target = "x86_64-unknown-linux-gnu"
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "x86_64-pc-windows-msvc",
+]
 
 [build-dependencies]
 tauri-plugin = { version = "2", features = ["build"] }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install the desktop underlay plugin by adding the following to your `Cargo.toml`
 
 ```toml
 [dependencies]
-tauri-plugin-desktop-underlay = "0.1.0"
+tauri-plugin-desktop-underlay = "0.1.1"
 ```
 
 You can install the JavaScript guest bindings using your preferred JavaScript package manager:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tauri-plugin-desktop-underlay-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "author": "Yao Xiao <yx2436@nyu.edu>",
   "homepage": "https://github.com/Charlie-XIAO/tauri-plugin-desktop-underlay",


### PR DESCRIPTION
0.1.0 docs.rs build failed: https://docs.rs/crate/tauri-plugin-desktop-underlay/0.1.0/builds/2099704/x86_64-unknown-linux-gnu.txt. See rust-lang/crates-build-env#172 which added the missing dependency.