### PR TITLE
maint: fix dependabot pnpm workspace issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,7 @@ version: 2
 updates:
   # Rust dependencies
   - package-ecosystem: cargo
-    directories:
-      - /
-      - /examples/desktop-clock/src-tauri
+    directory: /
     schedule:
       interval: weekly
     labels:
@@ -19,9 +17,7 @@ updates:
 
   # Node dependencies
   - package-ecosystem: npm
-    directories:
-      - /
-      - /examples/desktop-clock
+    directory: /
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
See #35. If specified as two separate directories, the lock file cannot be updated correctly.