### PR TITLE
maint: try fix dependabot cargo update and example identifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "examples/*/src-tauri"]
+members = [".", "examples/desktop-clock/src-tauri"]
 
 [package]
 authors      = ["Yao Xiao <yx2436@nyu.edu> (https://charlie-xiao.github.io/)"]

--- a/examples/desktop-clock/src-tauri/tauri.conf.json
+++ b/examples/desktop-clock/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "productName": "desktop-clock",
   "version": "0.0.0",
-  "identifier": "com.desktop-clock.app",
+  "identifier": "com.tauri.desktop-clock",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Example of Dependabot failure for cargo: https://github.com/Charlie-XIAO/tauri-plugin-desktop-underlay/actions/runs/15986088868. The error mentioned: failed to read `dependabot_tmp_dir/examples/*/src-tauri/Cargo.toml`, caused by: No such file or directory. This probably indicates that dependabot is not able to resolve this `*` path (though cargo workspace can). This PR tries to change to a solid path to see if dependabot can work correctly.

Also renaming the example app identifier because: The bundle identifier "com.desktop-clock.app" set in `tauri.conf.json identifier` ends with `.app`. This is not recommended because it conflicts with the application bundle extension on macOS.