### PR TITLE
doc: remove demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Tauri plugin for attaching a window to desktop, below icons and above wallpaper,
 - **MacOS:** ✅
 - **Windows:** ✅
 
-## Examples
+## Examples (With Demos)
 
-- [Desktop Clock](https://github.com/Charlie-XIAO/tauri-plugin-desktop-underlay/tree/main/examples/desktop-clock) [[Demo](https://github.com/user-attachments/assets/894a5afb-269e-4158-af13-add266a69576)]
+- [Desktop Clock](https://github.com/Charlie-XIAO/tauri-plugin-desktop-underlay/tree/main/examples/desktop-clock)
 
 ## Install
 


### PR DESCRIPTION
Towards #44.

It seems that Github has enforced stricter access control on user attachments (maybe related: https://github.com/orgs/community/discussions/159775), so the demo video link cannot be directly opened. The link works in GitHub README/issues/etc. though, so this PR just point to the example page instead.